### PR TITLE
fix(refresh-token-flow): add a layer of indirection to ensure refresh…

### DIFF
--- a/frontend/src/api/axios/authorizedAxios.ts
+++ b/frontend/src/api/axios/authorizedAxios.ts
@@ -33,7 +33,10 @@ const authorizedAxios = axios.create(baseAxiosConfig);
 export const getRequestInterceptor =
   (authContextValue: IAuthContext) =>
   (axiosRequestConfig: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
-    const accessToken = authContextValue.authState?.accessToken;
+    const accessToken = authContextValue.getAuthStore()?.accessToken;
+    if (!accessToken) {
+      throw Error('Access token not found!');
+    }
     if (accessToken && !axiosRequestConfig.headers.Authorization) {
       // do not overwrite existing authorization header if it exists as it may be a retry request
       axiosRequestConfig.headers.Authorization = `Bearer ${accessToken}`;
@@ -71,7 +74,7 @@ export const getResponseInterceptors = (
     }
 
     originalRequestConfig.retry = true;
-    const refreshToken = authContextValue.authState?.refreshToken;
+    const refreshToken = authContextValue.getAuthStore()?.refreshToken;
 
     // If user has no refresh token, sign out user
     if (!refreshToken) {

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -4,7 +4,8 @@ export interface IAuth {
 }
 
 export interface IAuthContext {
-  authState: IAuth | null;
+  isAuthenticated: boolean;
+  getAuthStore: () => IAuth | null;
   redirectToSignIn: () => void;
   signIn: (auth: IAuth) => void;
   signout: () => void;

--- a/frontend/src/navigation/NavBar.tsx
+++ b/frontend/src/navigation/NavBar.tsx
@@ -34,7 +34,7 @@ export default function NavBar() {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
-        <Toolbar>{authContext.authState ? logoutButton() : loginButton()}</Toolbar>
+        <Toolbar>{authContext.isAuthenticated ? logoutButton() : loginButton()}</Toolbar>
       </AppBar>
     </Box>
   );

--- a/frontend/src/pages/AuthRedirect.tsx
+++ b/frontend/src/pages/AuthRedirect.tsx
@@ -22,7 +22,7 @@ export default function AuthRedirect() {
     });
   });
 
-  if (auth.authState?.accessToken && auth.authState?.refreshToken) {
+  if (auth.isAuthenticated) {
     return <Navigate to="/dashboard" />;
   }
 

--- a/frontend/src/routes/ProtectedRoutes.tsx
+++ b/frontend/src/routes/ProtectedRoutes.tsx
@@ -5,7 +5,7 @@ export default function ProtectedRoutes() {
   const auth = useAuth();
   const location = useLocation();
 
-  if (!auth.authState) {
+  if (!auth.isAuthenticated) {
     // Redirect them to the /login page, but save the current location they were
     // trying to go to when they were redirected. This allows us to send them
     // along to that page after they login, which is a nicer user experience

--- a/frontend/src/routes/PublicOnlyRoutes.tsx
+++ b/frontend/src/routes/PublicOnlyRoutes.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../utils/hooks';
 export default function PublicOnlyRoutes() {
   const auth = useAuth();
   const location = useLocation();
-  if (auth.authState) {
+  if (auth.isAuthenticated) {
     return <Navigate to="/dashboard" state={{ from: location }} replace />;
   } else {
     return <Outlet />;

--- a/frontend/src/utils/hooks.ts
+++ b/frontend/src/utils/hooks.ts
@@ -1,26 +1,5 @@
 import React from 'react';
 import { AuthContext } from '../contextProviders/AuthContext';
-import { readLocalStorage, setLocalStorage } from './localStorageHelper';
-
-/**
- * This hook usage is similar to React.useState, the only difference
- * being that the state is also written to local storage at the specified key on state updates.
- *
- * When calling this hook, the value will take on the stored value in local storage (if any).
- * If this key-value does not exist in local storage yet, the default value will be used.
- */
-export function useLocalStorageState<T>(
-  key: string,
-  defaultValue: T,
-): [T, React.Dispatch<React.SetStateAction<T>>] {
-  const [value, setValue] = React.useState<T>(readLocalStorage(key, defaultValue));
-
-  React.useEffect(() => {
-    setLocalStorage(key, value);
-  }, [key, value]);
-
-  return [value, setValue];
-}
 
 export function useAuth() {
   return React.useContext(AuthContext);

--- a/frontend/src/utils/localStorageHelper.ts
+++ b/frontend/src/utils/localStorageHelper.ts
@@ -1,6 +1,6 @@
-export function readLocalStorage<T>(key: string, defaultValue: T) {
+export function readLocalStorage<T>(key: string) {
   const localStorageValue = window.localStorage.getItem(key);
-  return localStorageValue ? JSON.parse(localStorageValue) : defaultValue;
+  return localStorageValue ? (JSON.parse(localStorageValue) as T) : null;
 }
 
 export function setLocalStorage<T>(key: string, value: T) {


### PR DESCRIPTION
… flow always calls the latest refresh tokens

Previously, the refresh token flow was coupled to the React render lifecycle as the AuthContext only gets updated when its useLayoutEffect detects the change in React useState. This means that multiple refresh token flows in a row could happen before the useLayoutEffect is triggered, leading to subsequent refresh flows being called with the outdated refresh token inside the axios response interceptor.