### PR TITLE
Change auth role implementation

### DIFF
--- a/backend/apps/gateway/src/jwt/jwt.strategy.ts
+++ b/backend/apps/gateway/src/jwt/jwt.strategy.ts
@@ -15,6 +15,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload) {
-    return { id: payload.id, roleId: payload.roleId };
+    return { id: payload.id };
   }
 }

--- a/backend/apps/gateway/src/roles/roles.guard.ts
+++ b/backend/apps/gateway/src/roles/roles.guard.ts
@@ -1,13 +1,38 @@
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  OnModuleInit,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Role } from '@app/types/roles';
 import { ROLES_KEY } from './roles.decorator';
+import { Service } from '@app/microservice/services';
+import { ClientGrpc } from '@nestjs/microservices';
+import {
+  USER_PROFILE_SERVICE_NAME,
+  UserProfileServiceClient,
+} from '@app/microservice/interfaces/user';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable()
-export class RolesGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
+export class RolesGuard implements CanActivate, OnModuleInit {
+  private userProfileService: UserProfileServiceClient;
 
-  canActivate(context: ExecutionContext): boolean {
+  constructor(
+    private reflector: Reflector,
+    @Inject(Service.USER_SERVICE) private userServiceClient: ClientGrpc,
+  ) {}
+
+  onModuleInit() {
+    this.userProfileService =
+      this.userServiceClient.getService<UserProfileServiceClient>(
+        USER_PROFILE_SERVICE_NAME,
+      );
+  }
+
+  async canActivate(context: ExecutionContext) {
     const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
       context.getHandler(),
       context.getClass(),
@@ -16,6 +41,9 @@ export class RolesGuard implements CanActivate {
       return true;
     }
     const { user } = context.switchToHttp().getRequest();
-    return requiredRoles.some((role) => user.roleId === role);
+    const { roleId } = await firstValueFrom(
+      this.userProfileService.getUserProfile({ id: user.id }),
+    );
+    return requiredRoles.some((requiredRoleId) => roleId === requiredRoleId);
   }
 }

--- a/backend/apps/gateway/src/roles/roles.module.ts
+++ b/backend/apps/gateway/src/roles/roles.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { RolesGuard } from './roles.guard';
+import { registerGrpcClients } from '@app/microservice/utils';
+import { Service } from '@app/microservice/services';
 
 @Module({
+  imports: [registerGrpcClients([Service.USER_SERVICE])],
   providers: [
     {
       provide: APP_GUARD,

--- a/backend/apps/user/src/auth/auth.service.ts
+++ b/backend/apps/user/src/auth/auth.service.ts
@@ -51,10 +51,7 @@ export class AuthService {
    * If undefined, create a new database entry (i.e. when signing in)
    */
   async generateJwts(user, oldToken?: string) {
-    const payload: JwtPayload = {
-      id: user.id,
-      roleId: user.userProfile.roleId,
-    };
+    const payload: JwtPayload = { id: user.id };
     const accessToken: string = this.generateAccessToken(payload);
     const refreshToken: string = this.generateRefreshToken(payload);
 

--- a/backend/libs/types/src/jwt.ts
+++ b/backend/libs/types/src/jwt.ts
@@ -1,6 +1,5 @@
 export type JwtPayload = {
   id: string;
-  roleId: number;
 };
 export type JwtTokenConfig = {
   accessTokenSecret: string;


### PR DESCRIPTION
Previously, roles were stored in JWTs. This might pose security issues since the JWT can be modified while it is still valid. Roles have thus been removed from JWTs, and are checked in the backend by retrieving the user profile from the user service's database when the roles guard is hit.