### PR TITLE
User profile bugs

### DIFF
--- a/backend/apps/http-gateway/src/oauthProviders/google/google-oauth.strategy.ts
+++ b/backend/apps/http-gateway/src/oauthProviders/google/google-oauth.strategy.ts
@@ -52,7 +52,7 @@ export class GoogleOauthStrategy
   ) {
     const { id, name, emails } = profile;
     const defaultName = `${name.givenName} ${name.familyName}`;
-    const defautUsername = '';
+    const defautUsername = null;
 
     const oauthUser = {
       authProvider: AuthProvider.GOOGLE,

--- a/backend/apps/user/src/database/migrations/20231025070415_add-username-to-profile.ts
+++ b/backend/apps/user/src/database/migrations/20231025070415_add-username-to-profile.ts
@@ -7,5 +7,5 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema.dropTable('userProfiles');
+  return knex.schema.table('userProfiles', t => t.dropColumn('username'));
 }

--- a/backend/apps/user/src/database/migrations/20231025070415_add-username-to-profile.ts
+++ b/backend/apps/user/src/database/migrations/20231025070415_add-username-to-profile.ts
@@ -7,5 +7,5 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema.table('userProfiles', t => t.dropColumn('username'));
+  return knex.schema.table('userProfiles', (t) => t.dropColumn('username'));
 }

--- a/backend/apps/user/src/database/migrations/20231113025620_make-username-nullable.ts
+++ b/backend/apps/user/src/database/migrations/20231113025620_make-username-nullable.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('userProfiles', function (table) {
+    table.string('username').nullable().alter();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('userProfiles', t => t.string('username').notNullable().alter());
+}
+

--- a/backend/apps/user/src/database/migrations/20231113025620_make-username-nullable.ts
+++ b/backend/apps/user/src/database/migrations/20231113025620_make-username-nullable.ts
@@ -1,5 +1,4 @@
-import { Knex } from "knex";
-
+import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.alterTable('userProfiles', function (table) {
@@ -8,6 +7,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema.table('userProfiles', t => t.string('username').notNullable().alter());
+  return knex.schema.table('userProfiles', (t) =>
+    t.string('username').notNullable().alter(),
+  );
 }
-

--- a/frontend/src/contextProviders/ProfileContext.tsx
+++ b/frontend/src/contextProviders/ProfileContext.tsx
@@ -67,7 +67,7 @@ export const ProfileProvider = ({ children }: { children: React.ReactNode }) => 
   };
 
   const isOnboarded = useMemo(
-    () => (isProfileFetched ? username.length > 0 : true),
+    () => (isProfileFetched ? (!!username && username.length > 0) : true),
     [username, isProfileFetched],
   );
 

--- a/frontend/src/contextProviders/ProfileContext.tsx
+++ b/frontend/src/contextProviders/ProfileContext.tsx
@@ -67,7 +67,7 @@ export const ProfileProvider = ({ children }: { children: React.ReactNode }) => 
   };
 
   const isOnboarded = useMemo(
-    () => (isProfileFetched ? (!!username && username.length > 0) : true),
+    () => (isProfileFetched ? !!username && username.length > 0 : true),
     [username, isProfileFetched],
   );
 

--- a/frontend/src/pages/EditProfile.tsx
+++ b/frontend/src/pages/EditProfile.tsx
@@ -81,6 +81,7 @@ export default function EditProfile() {
   };
   const handleUpdateProfile = async () => {
     if (newUsername.length === 0) {
+      setUsernameValidationErrorText(EMPTY_USERNAME_ERROR);
       return;
     }
     try {

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -64,6 +64,7 @@ export default function Onboarding() {
 
   const handleSubmit = async () => {
     if (newUsername.length === 0) {
+      setUsernameValidationErrorText(EMPTY_USERNAME_ERROR);
       return;
     }
     try {
@@ -99,7 +100,7 @@ export default function Onboarding() {
             label="e.g. redsalmon42"
             value={newUsername}
             onChange={handleUsernameChange}
-            error={!!usernameValidationErrorText && isUsernameEdited}
+            error={!!usernameValidationErrorText}
             helperText={usernameValidationErrorText}
           />
           <Typography>Select your preferred language</Typography>


### PR DESCRIPTION
- Drop username column instead of entire table on migration that creates the username column
- Users couldn't create accounts simultaneously, because default username was an empty string when profile is created, which violated the unique constraint on usernames. Made usernames nullable and changed the default username to null. Users are not onboarded if they haven't confirmed a username
- Validation error for empty username showed error text but didn't show red text for users when they haven't placed any input but clicked submit